### PR TITLE
fix: preprend -> prepend

### DIFF
--- a/lib/SourceListMap.js
+++ b/lib/SourceListMap.js
@@ -41,7 +41,7 @@ class SourceListMap {
 		}
 	};
 
-	preprend(generatedCode, source, originalSource) {
+	prepend(generatedCode, source, originalSource) {
 		if(typeof generatedCode === "string") {
 			if(source) {
 				this.children.unshift(new SourceNode(generatedCode, source, originalSource));


### PR DESCRIPTION
Hello, thanks for the awesome library! I've come to notice that part of the public API is misspelled